### PR TITLE
Enable listening on IPv6

### DIFF
--- a/support/misc.c
+++ b/support/misc.c
@@ -343,7 +343,11 @@ u4_t kiwi_n2h_32(char *ip_str)
 	int n;
 	u4_t ip[4];
 	n = sscanf(ip_str, "%d.%d.%d.%d", &ip[0], &ip[1], &ip[2], &ip[3]);
-	assert(n == 4);
+	if (n != 4) {
+		n = sscanf(ip_str, "::ffff:%d.%d.%d.%d", &ip[0], &ip[1], &ip[2], &ip[3]); //IPv4-mapped address
+		if (n != 4)
+			return 0xffffffff; //IPv6
+	}
 	return (ip[3]&0xff) | ((ip[2]&0xff)<<8) | ((ip[1]&0xff)<<16) | ((ip[0]&0xff)<<24);
 }
 

--- a/web/web.c
+++ b/web/web.c
@@ -527,7 +527,7 @@ void web_server_init(ws_init_t type)
 		if (type == WS_INIT_CREATE) {
 			ui->server = mg_create_server(NULL, ev_handler);
 			char *s_port;
-			asprintf(&s_port, "%d", ui->port);
+			asprintf(&s_port, "[::]:%d", ui->port);
 			if (mg_set_option(ui->server, "listening_port", s_port) != NULL) {
 				lprintf("network port %d for \"%s\" in use\n", ui->port, ui->name);
 				lprintf("app already running in background?\ntry \"make stop\" (or \"m stop\") first\n");


### PR DESCRIPTION
Modify mongoose to correctly listen on IPv6, enable listening on
[::]:port and handle IPv4-mapped IPv6 addresses in check for local
network.

Local network check for IPv6 addresses always returns false currently.