### PR TITLE
timer: use clock_gettime() with CLOCK_MONOTONIC

### DIFF
--- a/platform/beaglebone_black/timer.c
+++ b/platform/beaglebone_black/timer.c
@@ -6,6 +6,7 @@
 
 #include <stdlib.h>
 #include <unistd.h>
+#include <time.h>
 #include <sys/time.h>
 
 static bool timer_init = false;
@@ -13,58 +14,58 @@ static u4_t timer_epoch_sec;
 
 static void timer_epoch()
 {
-	struct timeval tv;
+	struct timespec ts;
 
-	gettimeofday(&tv, 0);
-	timer_epoch_sec = tv.tv_sec;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	timer_epoch_sec = ts.tv_sec;
 	timer_init = true;
 }
 
 // overflows 136 years after timer_epoch_sec
 u4_t timer_sec(void)
 {
-	struct timeval tv;
+	struct timespec ts;
 
 	if (!timer_init) timer_epoch();
-	gettimeofday(&tv, 0);
-    return tv.tv_sec - timer_epoch_sec;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec - timer_epoch_sec;
 }
 
 // overflows 49.7 days after timer_epoch_sec
 u4_t timer_ms(void)
 {
-	struct timeval tv;
+	struct timespec ts;
 
 	if (!timer_init) timer_epoch();
-	gettimeofday(&tv, 0);
-	int msec = tv.tv_usec/1000;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	int msec = ts.tv_nsec/1000000;
 	assert(msec >= 0 && msec < 1000);
-    return (tv.tv_sec - timer_epoch_sec)*1000 + msec;
+    return (ts.tv_sec - timer_epoch_sec)*1000 + msec;
 }
 
 // overflows 1.2 hours after timer_epoch_sec
 u4_t timer_us(void)
 {
-	struct timeval tv;
+	struct timespec ts;
 
 	if (!timer_init) timer_epoch();
-	gettimeofday(&tv, 0);
-	int usec = tv.tv_usec;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	int usec = ts.tv_nsec / 1000;
 	assert(usec >= 0 && usec < 1000000);
-    return (tv.tv_sec - timer_epoch_sec)*1000000 + usec;	// ignore overflow
+    return (ts.tv_sec - timer_epoch_sec)*1000000 + usec;	// ignore overflow
 }
 
 // never overflows (effectively)
 u64_t timer_us64(void)
 {
-	struct timeval tv;
+	struct timespec ts;
 	u64_t t;
 
 	if (!timer_init) timer_epoch();
-	gettimeofday(&tv, 0);
-	int usec = tv.tv_usec;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	int usec = ts.tv_nsec / 1000;
 	assert(usec >= 0 && usec < 1000000);
-	t = tv.tv_sec - timer_epoch_sec;
+	t = ts.tv_sec - timer_epoch_sec;
 	t *= 1000000;
 	t += usec;
     return t;
@@ -72,11 +73,9 @@ u64_t timer_us64(void)
 
 unsigned Microseconds(void) {
     struct timespec ts;
-    struct timeval tv;
     
 	if (!timer_init) timer_epoch();
-    gettimeofday(&tv, 0);
-    TIMEVAL_TO_TIMESPEC(&tv, &ts);
+	clock_gettime(CLOCK_MONOTONIC, &ts);
 	int usec = ts.tv_nsec/1000;
 	assert(usec >= 0 && usec < 1000000);
     return (ts.tv_sec - timer_epoch_sec)*1000000 + usec;
@@ -84,11 +83,9 @@ unsigned Microseconds(void) {
 
 unsigned nonSim_Microseconds(void) {
     struct timespec ts;
-    struct timeval tv;
     
 	if (!timer_init) timer_epoch();
-    gettimeofday(&tv, 0);
-    TIMEVAL_TO_TIMESPEC(&tv, &ts);
+	clock_gettime(CLOCK_MONOTONIC, &ts);
 	int usec = ts.tv_nsec/1000;
 	assert(usec >= 0 && usec < 1000000);
     return (ts.tv_sec - timer_epoch_sec)*1000000 + usec;


### PR DESCRIPTION
Instead of using gettimeofday() which gets adjusted to the wall-clock
by NTP use clock_gettime() which CLOCK_MONOTONIC as a source which
is a monotonic clock only influenced by drift-corrections from NTP,
not synchronized with the wall-clock.

This fixes wrong uptime calculation.