### PR TITLE
Don't disable the /status HTTP query

### DIFF
--- a/rx/rx_server_ajax.cpp
+++ b/rx/rx_server_ajax.cpp
@@ -92,7 +92,7 @@ char *rx_server_ajax(struct mg_connection *mc, char *buf, size_t *size)
 		break;
 
 	case STREAM_SDR_HU:
-		if (cfg_bool("sdr_hu_register", NULL, CFG_OPTIONAL) != true) return NULL;
+		//if (cfg_bool("sdr_hu_register", NULL, CFG_OPTIONAL) != true) return NULL;
 		static time_t avatar_ctime;
 		// the avatar file is in the in-memory store, so it's not going to be changing after server start
 		if (avatar_ctime == 0) time(&avatar_ctime);


### PR DESCRIPTION
While the intent seems to be that it's internally used by sdr.hu, and therefore seemingly unnecessary when the receiver is not registered there, it blocks off the only means receiver metadata is provided in a machine-friendly format. This makes it much more difficult and/or less user-friendly for native apps to create offline lists of receivers not published at sdr.hu.

Of note is that this restriction is not present in vanilla OpenWebRX.