### PR TITLE
extend waterfall vertically

### DIFF
--- a/web/openwebrx/openwebrx.js
+++ b/web/openwebrx/openwebrx.js
@@ -2327,6 +2327,7 @@ function resize_waterfall_container(check_init)
 {
 	if (check_init && !waterfall_setup_done) return;
 	canvas_container.style.height = (window.innerHeight - html("id-top-container").clientHeight - html("id-scale-container").clientHeight).toString()+"px";
+	waterfall_scrollable_height = html("id-kiwi-container").clientHeight - html("id-scale-container").clientHeight;
 }
 
 var waterfall_delay = 0;


### PR DESCRIPTION
Fix: "Waterfall won't extend vertically beyond about 1200 pixels" in the KiwiSDR master bug list.

My laptop is 14-inchi(1366 x 768). Instead of a high-resolution display, I tested it with a zoom-out button of Firefox. browser page has expand 2230 pixels of vertical resolution into my laptop.

See: [Font size and zoom - increase the size of web pages | Firefox Help](https://support.mozilla.org/en-US/kb/font-size-and-zoom-increase-size-of-web-pages)

Thanks.