### PR TITLE
Fix the numerical format on the scale marker #38

### DIFF
--- a/web/openwebrx/openwebrx.js
+++ b/web/openwebrx/openwebrx.js
@@ -1118,7 +1118,7 @@ var scale_markers_levels=[
 		"estimated_text_width":70,
 		"format":"{x} ",
 		"pre_divide":1000000,
-		"decimals":1
+		"decimals":3
 	}
 ];
 


### PR DESCRIPTION
fix the decimal digits after the decimal point on the scale marker, when using wide display and the kiwi max-zoom-level. 