### PR TITLE
allows spectrum-width to fit window

### DIFF
--- a/web/openwebrx/openwebrx.js
+++ b/web/openwebrx/openwebrx.js
@@ -1989,6 +1989,7 @@ function resize_canvases(zoom)
 	});
 	canvas_phantom.style.width=new_width;
 	canvas_phantom.style.left=zoom_value;
+	spectrum_canvas.style.width = new_width;
 }
 
 


### PR DESCRIPTION
Fix: "Spectrum doesn't appear same width as waterfall" in the KiwiSDR master bug list.