### PR TITLE
SQRT function applied to restricted range

### DIFF
--- a/web/openwebrx/openwebrx.js
+++ b/web/openwebrx/openwebrx.js
@@ -2508,8 +2508,26 @@ function do_waterfall_index(db_value, sqrt)
 	var relative_value = db_value - mindb;
 	var value_percent = relative_value/full_scale;
 	
-	if (sqrt == 1)
+	switch (+sqrt) {
+	
+	case 0:
+		break;
+	case 1:
 		value_percent = Math.sqrt(value_percent);
+		break;
+	case 2:
+		if (value_percent > 0.21 && value_percent < 0.5)
+			value_percent = 0.2 + (4 + Math.log10(value_percent - 0.2)) * 0.09;
+		break;
+	case 3:
+		if (value_percent > 0.31 && value_percent < 0.6)
+			value_percent = 0.3 + (5 + Math.log10(value_percent - 0.3)) * 0.07;
+		break;
+	case 4:
+		if (value_percent > 0.41 && value_percent < 0.7)
+			value_percent = 0.4 + (6 + Math.log10(value_percent - 0.4)) * 0.055;
+		break;
+	}
 	
 	var i = value_percent*255;
 	i = Math.round(i);


### PR DESCRIPTION
## improvement of SQRT function

This patch are improvement of the SQRT function. The new function applied to a restricted spectrum range. that become available effectively for weak signal observation. Each new function has a different working range. (fn1, fn2, fn3)

![applied_range](https://cloud.githubusercontent.com/assets/16305594/19925359/fcbc2fe2-a132-11e6-99d3-1b39235b3090.png)


## applied range:

*   `kiwi:8073/?sqrt=2` => fn1, apply to between 21% and 50% spectrum range
*   `kiwi:8073/?sqrt=3` => fn2, apply to between 31% and 60% spectrum range
*   `kiwi:8073/?sqrt=4` => fn3, apply to between 41% and 70% spectrum range

## at 60kHz JJY on Kiwi

In my situation, `sqrt=4`(fn3) was more effectively, I felt.

### at `sqrt=0`, default liner mode
![jjy_sqrt_0](https://cloud.githubusercontent.com/assets/16305594/19925413/33bbeea6-a133-11e6-971a-e42081e2d1ff.png)

----
### at `sqrt=1`, SQRT function
![jjy_sqrt_1](https://cloud.githubusercontent.com/assets/16305594/19925418/391319b0-a133-11e6-9bcf-05cfa2acc64a.png)

----
### at `sqrt=2`, fn1
![jjy_sqrt_2](https://cloud.githubusercontent.com/assets/16305594/19925421/3fb40ca2-a133-11e6-9758-15339f7fc9d8.png)

----
### at `sqrt=3`, fn2
![jjy_sqrt_3](https://cloud.githubusercontent.com/assets/16305594/19925425/42dca132-a133-11e6-9844-e127f703e899.png)

----
### at `sqrt=4`, fn3
![jjy_sqrt_4](https://cloud.githubusercontent.com/assets/16305594/19925432/46fc04ba-a133-11e6-849d-7d2ec6388286.png)
