### PR TITLE
To improve the code of non-recommended

### DIFF
--- a/web/extensions/S_meter/S_meter.js
+++ b/web/extensions/S_meter/S_meter.js
@@ -130,7 +130,7 @@ function S_meter_controls_setup()
 	
 	ext_send('SET run=1');
 
-	S_meter_update_interval = setInterval('S_meter_update(0)', 1000);
+	S_meter_update_interval = setInterval(function() {S_meter_update(0);}, 1000);
 	S_meter_update(1);
 }
 
@@ -201,7 +201,7 @@ function S_meter_marker_select_cb(path, idx)
 function S_meter_clear_cb(path, val)
 {
 	S_meter_clear();
-	setTimeout('w3_radio_unhighlight('+ q(path) +')', w3_highlight_time);
+	setTimeout(function() {w3_radio_unhighlight(path);}, w3_highlight_time);
 }
 
 var S_meter_update_interval;

--- a/web/extensions/ext.js
+++ b/web/extensions/ext.js
@@ -272,7 +272,7 @@ function extint_override(name)
 	for (var i=0; i < extint_names.length; i++) {
 		if (extint_names[i].includes(name)) {
 			//console.log('extint_override match='+ extint_names[i]);
-			setTimeout('extint_select('+ i +')', 3000);
+			setTimeout(function() {extint_select(i);}, 3000);
 			break;
 		}
 	}

--- a/web/extensions/integrate/integrate.js
+++ b/web/extensions/integrate/integrate.js
@@ -267,7 +267,7 @@ function integrate_controls_setup()
 	ext_send('SET run=1');
 	integrate_clear();
 
-	integrate_update_interval = setInterval('integrate_update()', 1000);
+	integrate_update_interval = setInterval(integrate_update, 1000);
 }
 
 function integrate_resize()
@@ -439,7 +439,7 @@ function integrate_mindb_cb(path, val)
 function integrate_clear_cb(path, val)
 {
 	integrate_clear();
-	setTimeout('w3_radio_unhighlight('+ q(path) +')', w3_highlight_time);
+	setTimeout(function() {w3_radio_unhighlight(path);}, w3_highlight_time);
 }
 
 // hook that is called when controls panel is closed

--- a/web/extensions/iq_display/iq_display.js
+++ b/web/extensions/iq_display/iq_display.js
@@ -224,7 +224,7 @@ function iq_display_draw_select_cb(path, idx)
 	iq_display_draw = +idx;
 	ext_send('SET draw='+ iq_display_draw);
 	kiwi_clearInterval(iq_display_update_interval);
-	iq_display_update_interval = setInterval('iq_display_update()', 250);
+	iq_display_update_interval = setInterval(iq_display_update, 250);
 	iq_display_clear();
 }
 
@@ -237,7 +237,7 @@ function iq_display_offset_cb(path, val)
 function iq_display_clear_cb(path, val)
 {
 	iq_display_clear();
-	setTimeout('w3_radio_unhighlight('+ q(path) +')', w3_highlight_time);
+	setTimeout(function() {w3_radio_unhighlight(path);}, w3_highlight_time);
 }
 
 function iq_display_IQ_bal_adjust()
@@ -250,7 +250,7 @@ function iq_display_IQ_balance_cb(path, val)
 {
 	var func = function(badp) { if (!badp) iq_display_IQ_bal_adjust(); };
 	ext_hasCredential('admin', func);
-	setTimeout('w3_radio_unhighlight('+ q(path) +')', w3_highlight_time);
+	setTimeout(function() {w3_radio_unhighlight(path);}, w3_highlight_time);
 }
 
 function iq_display_blur()

--- a/web/extensions/s4285/s4285.js
+++ b/web/extensions/s4285/s4285.js
@@ -220,7 +220,7 @@ function s4285_draw_select_cb(path, idx)
 	ext_send('SET draw='+ idx);
 	kiwi_clearInterval(s4285_density_interval);
 	if (idx == s4285_cmd_e.IQ_DENSITY) {
-		s4285_density_interval = setInterval('s4285_density_draw()', 250);
+		s4285_density_interval = setInterval(s4285_density_draw, 250);
 	}
 	s4285_clear();
 }
@@ -228,7 +228,7 @@ function s4285_draw_select_cb(path, idx)
 function s4285_clear_cb(path, val)
 {
 	s4285_clear();
-	setTimeout('w3_radio_unhighlight('+ q(path) +')', w3_highlight_time);
+	setTimeout(function() {w3_radio_unhighlight(path);}, w3_highlight_time);
 }
 
 function s4285_blur()

--- a/web/extensions/wspr/wspr.js
+++ b/web/extensions/wspr/wspr.js
@@ -408,11 +408,11 @@ function wspr_visible(v)
 	visible_block('id-wspr-scale', v);
 
 	if (v) {
-		wspr_pie_interval = setInterval('wspr_draw_pie()', 1000);
+		wspr_pie_interval = setInterval(wspr_draw_pie, 1000);
 		wspr_draw_pie();
    	wspr_draw_scale(100);
 		wspr_reset();
-		wspr_upload_timeout = setTimeout('wspr_upload(wspr_report_e.STATUS)', 1000);
+		wspr_upload_timeout = setTimeout(function() {wspr_upload(wspr_report_e.STATUS);}, 1000);
 	} else {
    	kiwi_clearTimeout(wspr_upload_timeout);
    	kiwi_clearInterval(wspr_pie_interval);
@@ -470,7 +470,7 @@ function wspr_upload(type, s)
 
 	// don't even report status if not uploading
 	if (!valid || (html('id-wspr-upload').checked == false)) {
-		wspr_upload_timeout = setTimeout('wspr_upload(wspr_report_e.STATUS)', 1*60*1000);	// check again in another minute
+		wspr_upload_timeout = setTimeout(function() {wspr_upload(wspr_report_e.STATUS);}, 1*60*1000);	// check again in another minute
 		return;
 	}
 	
@@ -524,7 +524,7 @@ function wspr_upload(type, s)
 	}
 
 	// report status every six minutes
-	if (!spot) wspr_upload_timeout = setTimeout('wspr_upload(wspr_report_e.STATUS)', 6*60*1000);
+	if (!spot) wspr_upload_timeout = setTimeout(function() {wspr_upload(wspr_report_e.STATUS);}, 6*60*1000);
 }
 
 var wspr_cur_status = 0;
@@ -595,7 +595,7 @@ function wspr_freq(b)
    
    // promptly notify band change
    kiwi_clearTimeout(wspr_upload_timeout);
-   wspr_upload_timeout = setTimeout('wspr_upload(wspr_report_e.STATUS)', 1000);
+   wspr_upload_timeout = setTimeout(function() {wspr_upload(wspr_report_e.STATUS);}, 1000);
 }
 
 var wspr_fbn = 0;

--- a/web/kiwi/admin.js
+++ b/web/kiwi/admin.js
@@ -492,7 +492,7 @@ function sdr_hu_focus()
 
 	// only get updates while the sdr_hu tab is selected
 	ext_send("SET sdr_hu_update");
-	sdr_hu_interval = setInterval('ext_send("SET sdr_hu_update")', 2000);
+	sdr_hu_interval = setInterval(function() {ext_send("SET sdr_hu_update");}, 2000);
 }
 
 function sdr_hu_blur(id)
@@ -592,7 +592,7 @@ function network_dhcp_static_update_cb(path, idx)
 	else
 		ext_send('SET use_DHCP');
 
-	setTimeout('w3_radio_unhighlight('+ q(path) +')', w3_highlight_time);
+	setTimeout(function() {w3_radio_unhighlight(path);}, w3_highlight_time);
 }
 
 function network_use_static_cb(path, idx, first)
@@ -778,7 +778,7 @@ function update_html()
 function update_check_now_cb(id, idx)
 {
 	ext_send('SET force_check=1 force_build=0');
-	setTimeout('w3_radio_unhighlight('+ q(id) +')', w3_highlight_time);
+	setTimeout(function() {w3_radio_unhighlight(id);}, w3_highlight_time);
 	w3_el_id('msg-update').innerHTML = 'Checking <i class="fa fa-refresh fa-spin"></i>';
 	ext_send('SET CHECK_UPDATE');
 }
@@ -786,7 +786,7 @@ function update_check_now_cb(id, idx)
 function update_build_now_cb(id, idx)
 {
 	ext_send('SET force_check=1 force_build=1');
-	setTimeout('w3_radio_unhighlight('+ q(id) +')', w3_highlight_time);
+	setTimeout(function() {w3_radio_unhighlight(id);}, w3_highlight_time);
 	w3_show_block('id-build-restart');
 }
 
@@ -823,7 +823,7 @@ function gps_focus(id)
 {
 	// only get updates while the gps tab is selected
 	ext_send("SET gps_update");
-	gps_interval = setInterval('ext_send("SET gps_update")', 1000);
+	gps_interval = setInterval(function() {ext_send("SET gps_update");}, 1000);
 }
 
 function gps_blur(id)
@@ -990,7 +990,7 @@ function log_focus(id)
 	log_selected = true;
 	log_resize();
 	log_update();
-	log_interval = setInterval('log_update()', 3000);
+	log_interval = setInterval(log_update, 3000);
 }
 
 function log_blur(id)
@@ -1360,7 +1360,7 @@ function admin_wait_then_reload(secs, msg)
 	
 	if (secs) {
 		admin_reload_rem = admin_reload_secs = secs;
-		setInterval('admin_draw_pie()', 1000);
+		setInterval(admin_draw_pie, 1000);
 		admin_draw_pie();
 	}
 }

--- a/web/kiwi/kiwi.js
+++ b/web/kiwi/kiwi.js
@@ -350,7 +350,7 @@ function kiwi_geolocate()
 {
 	// FIXME if one times-out try the other
 	//kiwi_ajax('http://freegeoip.net/json/', 'callback_freegeoip', function() { setTimeout('kiwi_geolocate();', 1000); } );
-	kiwi_ajax('http://ipinfo.io/json/', 'callback_ipinfo', function() { setTimeout('kiwi_geolocate();', 1000); } );
+	kiwi_ajax('http://ipinfo.io/json/', 'callback_ipinfo', function() {setTimeout(kiwi_geolocate, 1000); } );
 }
 
 var geo = "";
@@ -597,7 +597,7 @@ function stats_update()
 		need_config = false;
 	}
 	msg_send('SET STATS_UPD ch='+ rx_chan);
-	setTimeout('stats_update()', stats_interval);
+	setTimeout(stats_update, stats_interval);
 }
 
 function update_TOD()
@@ -713,7 +713,7 @@ function users_update()
 {
 	//console.log('users_update');
 	msg_send('SET GET_USERS');
-	setTimeout('users_update()', users_interval);
+	setTimeout(users_update, users_interval);
 }
 
 function user_cb(obj)

--- a/web/kiwi/mfg.js
+++ b/web/kiwi/mfg.js
@@ -162,7 +162,7 @@ function mfg_sd_write()
 
 	sd_progress = -1;
 	mfg_sd_progress();
-	mfg_sd_interval = setInterval('mfg_sd_progress()', 1000);
+	mfg_sd_interval = setInterval(mfg_sd_progress, 1000);
 
 	html('id-progress-icon').innerHTML = refresh_icon;
 

--- a/web/openwebrx/openwebrx.js
+++ b/web/openwebrx/openwebrx.js
@@ -189,8 +189,8 @@ function kiwi_main()
 	smeter_init();
 	extint_init();
 	
-	window.setTimeout(function(){window.setInterval(send_keepalive,5000);},5000);
-	window.setTimeout(function(){window.setInterval(update_TOD,1000);},1000);
+	window.setTimeout(function() {window.setInterval(send_keepalive, 5000);}, 5000);
+	window.setTimeout(function() {window.setInterval(update_TOD, 1000);}, 1000);
 	window.addEventListener("resize", openwebrx_resize);
 
 	// FIXME: eliminate these
@@ -268,7 +268,7 @@ function init_panel_toggle(type, panel, scrollable, timeo, color)
 
 	if (timeo != undefined) {
 		if (timeo) {
-			setTimeout('toggle_panel('+ q(panel) +')', timeo);
+			setTimeout(function() {toggle_panel(panel);}, timeo);
 		} else
 		if (timeo == popt.CLOSE) {
 			toggle_panel(panel);		// make it go away immediately
@@ -3021,7 +3021,7 @@ function try_freqset_update_ui()
 		freqset_update_ui();
 		mkenvelopes(get_visible_freq_range());
 	} else {
-		setTimeout('try_freqset_update_ui()', 1000);
+		setTimeout(try_freqset_update_ui, 1000);
 	}
 }
 
@@ -3102,7 +3102,7 @@ function freqset_keyup(obj, evt)
 		}
 	}
 	
-	freqset_tout = setTimeout('freqset_complete(1)', 3000);
+	freqset_tout = setTimeout(function() {freqset_complete(1);}, 3000);
 }
 
 var num_step_buttons = 6;
@@ -3540,7 +3540,7 @@ function dx_schedule_update()
 {
 	kiwi_clearTimeout(dx_update_timeout);
 	dx_div.innerHTML = "";
-	dx_update_timeout = setTimeout('dx_update()', dx_update_delay);
+	dx_update_timeout = setTimeout(dx_update, dx_update_delay);
 }
 
 function dx_update()
@@ -3873,7 +3873,7 @@ function dx_modify_cb(id, val)
 	mode |= type;
 	fft_send('SET DX_UPD g='+ dxo.gid +' f='+ dxo.f +' o='+ dxo.o +' m='+ mode +
 		' i='+ encodeURIComponent(dxo.i +'x') +' n='+ encodeURIComponent(dxo.n +'x'));
-	setTimeout('dx_close_edit_panel('+ q(id) +')', 250);
+	setTimeout(function() {dx_close_edit_panel(id);}, 250);
 }
 
 function dx_add_cb(id, val)
@@ -3885,7 +3885,7 @@ function dx_add_cb(id, val)
 	mode |= type;
 	fft_send('SET DX_UPD g=-1 f='+ dxo.f +' o='+ dxo.o +' m='+ mode +
 		' i='+ encodeURIComponent(dxo.i +'x') +' n='+ encodeURIComponent(dxo.n +'x'));
-	setTimeout('dx_close_edit_panel('+ q(id) +')', 250);
+	setTimeout(function() {dx_close_edit_panel(id);}, 250);
 }
 
 function dx_delete_cb(id, val)
@@ -3893,7 +3893,7 @@ function dx_delete_cb(id, val)
 	//console.log('DX COMMIT delete entry #'+ dxo.gid);
 	//console.log(dxo);
 	fft_send('SET DX_UPD g='+ dxo.gid +' f=-1');
-	setTimeout('dx_close_edit_panel('+ q(id) +')', 250);
+	setTimeout(function() {dx_close_edit_panel(id);}, 250);
 }
 
 function dx_click(ev, gid)
@@ -3999,7 +3999,7 @@ function smeter_init()
 	}
 
 	line_stroke(sMeter_ctx, 0, 5, "black", 0,y,w,y);
-	setInterval('update_smeter()', 100);
+	setInterval(update_smeter, 100);
 }
 
 var sm_px = 0, sm_timeout = 0, sm_interval = 10;
@@ -4075,7 +4075,7 @@ function ident_keyup(obj, evt)
 		return;
 	}
 	
-	ident_tout = setTimeout('ident_complete()', 5000);
+	ident_tout = setTimeout(ident_complete, 5000);
 }
 
 


### PR DESCRIPTION
I noticed when I was investigating why the code of openwebrx.js was not displayed in dev-tools of the Firefox.

```
intervalID = window.setInterval(code, delay);
timeoutID = window.setTimeout(code, delay);
```
This syntax is not recommended for the same reasons that make using eval() a security risk.

See also:
*   [WindowTimers.setInterval() | MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setInterval)
*   [WindowTimers.setTimeout() | MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setTimeout)

