### PR TITLE
Add link to IRC chat room in message box

### DIFF
--- a/web/openwebrx/openwebrx.js
+++ b/web/openwebrx/openwebrx.js
@@ -4455,6 +4455,7 @@ function panels_setup()
 		(admin_email? '<a href="javascript:sendmail(\''+ enc(admin_email) +'\');"><strong>Owner/Admin</strong></a>, ' : '') +
 		'<a href="javascript:sendmail(\'pvsslqwChjtjpgq-`ln\');"><strong>KiwiSDR</strong></a>, ' +
 		'<a href="javascript:sendmail(\'kb4jonCpgq-kv\');"><strong>OpenWebRX</strong></a> ' +
+		'| <a href="https://kiwiirc.com/client/chat.freenode.net/#kiwisdr" target="_blank"><strong>Chat</strong></a> ' +
 		'<span id="id-problems"></span></div>' +
 		'<div id="id-status-msg"></div>' +
 		'<span id="id-msg-config"></span><br/>' +


### PR DESCRIPTION
For now the link is hard-coded to #kiwisdr on freenode through a Kiwi
IRC web client, but could be made configurable in the future.

This addresses https://github.com/jks-prv/Beagle_SDR_GPS/issues/60 and http://valentfx.com/vanilla/discussion/581/messaging-users-via-your-name-or-callsign-box