### PR TITLE
left side 150 pixels FAX image does not respond

### DIFF
--- a/web/extensions/fax/fax.js
+++ b/web/extensions/fax/fax.js
@@ -349,7 +349,7 @@ function fax_pre_select_cb(path, idx, first)
 function fax_mousedown(evt)
 {
 	//event_dump(evt, 'FFT');
-	var offset = (evt.clientX? evt.clientX : (evt.offsetX? evt.offsetX : evt.layerX)) - fax_startx;
+	var offset = (evt.clientX? evt.clientX : (evt.offsetX? evt.offsetX : evt.layerX));
 	if (!evt.shiftKey || offset < fax_startx || offset >= fax_tw) return;
 	offset = ((offset - fax_startx) / fax_w).toFixed(6);     // normalize
 	ext_send('SET fax_shift='+ offset);


### PR DESCRIPTION
Left side 150 pixels of the FAX image does not respond to "shift + click".
I think that the offset "fax_startx" has been doubly calculated.