### PR TITLE
GPS time-stamp correction for AGC delay

### DIFF
--- a/rx/CuteSDR/agc.h
+++ b/rx/CuteSDR/agc.h
@@ -24,7 +24,9 @@ public:
 	void ProcessData(int Length, TYPECPX* pInData, TYPECPX* pOutData);
 	void ProcessData(int Length, TYPECPX* pInData, TYPEMONO16* pOutData);
 
-private:
+	int GetDelaySamples() const { return m_DelaySamples; }
+
+ private:
 	bool m_AgcOn;				//internal copy of AGC settings parameters
 	bool m_UseHang;
 	int m_Threshold;

--- a/rx/rx_sound.cpp
+++ b/rx/rx_sound.cpp
@@ -643,7 +643,12 @@ void c2s_sound(void *param)
 				continue;
 			}
 			// correct GPS timestamp for offset in the FIR filter
-			gps_ts[rx_chan].gpssec = fmod(gps_ts[rx_chan].gpssec + RX1_DECIM*RX2_DECIM * (NRX_SAMPS - gps_ts[rx_chan].fir_pos) / clk.adc_clock_base,
+			//  (1) delay in FIR filter
+			int sample_filter_delays = NRX_SAMPS - gps_ts[rx_chan].fir_pos;
+			//  (2) delay in AGC (if on)
+			if (agc)
+				sample_filter_delays -= m_Agc[rx_chan].GetDelaySamples();
+			gps_ts[rx_chan].gpssec = fmod(gps_week_sec + gps_ts[rx_chan].gpssec + RX1_DECIM*RX2_DECIM * sample_filter_delays / clk.adc_clock_base,
 										  gps_week_sec);
 			out_pkt_iq.h.gpssec  = u4_t(gps_ts[rx_chan].last_gpssec);
 			out_pkt_iq.h.gpsnsec = u4_t(1e9*(gps_ts[rx_chan].last_gpssec-out_pkt_iq.h.gpssec));


### PR DESCRIPTION
When the AGC is enabled the I/Q samples are delayed by the processing delay of the AGC filter. 

This delay which is defined in https://github.com/jks-prv/Beagle_SDR_GPS/blob/master/rx/CuteSDR/agc.cpp#L52 corresponds to 180 samples and is subtracted from the GPS time-stamps when the AGC is on.

( `RX1_DECIM*RX2_DECIM/clk.adc_clock_base` is 1/(current sample rate))