### PR TITLE
using NEON SIMD for GPS search

### DIFF
--- a/gps/cacode.h
+++ b/gps/cacode.h
@@ -30,7 +30,7 @@ struct CACODE {
       memset(g2+1, 1, 10);
    }
 
-   int Chip() {
+   int Chip() const {
       return g1[10] ^ *tap[0] ^ *tap[1];
    }
 
@@ -41,13 +41,14 @@ struct CACODE {
       memmove(g2+1, g2, 10);
    }
 
-   bool Epoch() {
+   bool Epoch() const {
       return g1[10] & g1[9] & g1[8] & g1[7] & g1[6] & g1[5] & g1[4] & g1[3] & g1[2] & g1[1];
    }
 
-   unsigned GetG1() {
+   unsigned GetG1() const {
       unsigned ret=0;
-      for (int bit=0; bit<10; bit++) ret += ret + g1[10-bit];
+      for (int bit=0; bit<10; bit++)
+		  ret += ret + g1[10-bit];
       return ret;
    }
 };

--- a/gps/search.cpp
+++ b/gps/search.cpp
@@ -38,6 +38,7 @@
 #include "spi.h"
 #include "cacode.h"
 #include "debug.h"
+#include "simd.h"
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -86,17 +87,19 @@ static bool Busy[NUM_SATS];
 
 static fftwf_plan fwd_plan, rev_plan;
 
-static fftwf_complex code[NUM_SATS][FFT_LEN];
+// code[sv][...] holds two copies of the FFT: modulo operation on the index is not needed
+static fftwf_complex code[NUM_SATS][2*FFT_LEN] __attribute__ ((aligned (16)));
 
-static fftwf_complex fwd_buf[FFT_LEN],
-                     rev_buf[FFT_LEN];
-
-static fftwf_complex copy_buf[NSAMPLES];
+// fwd_buf is also used for decimating the data
+static fftwf_complex fwd_buf[NSAMPLES] __attribute__ ((aligned (16)));
+static fftwf_complex rev_buf[FFT_LEN]  __attribute__ ((aligned (16)));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-float inline Bipolar(int bit) {
-    return bit? -1.0 : +1.0;
+static float inline Bipolar(int bit) {
+	// this is a branchless version of
+	//	return bit ? -1.0 : +1.0;
+    return -1.0f*(bit!=0) + 1.0f*(bit==0);
 }
 
 #include <ctype.h>
@@ -128,109 +131,92 @@ void SearchParams(int argc, char *argv[]) {
 	}
 }
 
-static char bits[NSAMPLES][2];
+static char bits[NSAMPLES][2]  __attribute__ ((aligned (16)));
 #define NTAPS	31
  
- // half-band filter
- #define FT	0   // remez
- static float COEF[NTAPS][2] = {
- //	remez		firwin
+// half-band filter
+#define FT	0
+static float COEF[NTAPS][2] __attribute__ ((aligned (16))) = {
+	// remez	    firwin
 	-0.010233,   -0.001888,
-	0.000000,    0.000000,
-	0.010668,    0.003862,
-	0.000000,    0.000000,
+	 0.000000,    0.000000,
+	 0.010668,    0.003862,
+	 0.000000,    0.000000,
 	-0.016324,   -0.008242,
-	0.000000,    0.000000,
-	0.024377,    0.015947,
-	0.000000,    0.000000,
+	 0.000000,    0.000000,
+	 0.024377,    0.015947,
+	 0.000000,    0.000000,
 	-0.036482,   -0.028677,
-	0.000000,    0.000000,
-	0.056990,    0.050719,
-	0.000000,    0.000000,
+	 0.000000,    0.000000,
+	 0.056990,    0.050719,
+	 0.000000,    0.000000,
 	-0.101993,   -0.098016,
-	0.000000,    0.000000,
+	 0.000000,    0.000000,
 
-	0.316926,    0.315942,
-	0.500009,    0.500706,
-	0.316926,    0.315942,
+	 0.316926,    0.315942,
+	 0.500009,    0.500706,
+	 0.316926,    0.315942,
 
-	0.000000,    0.000000,
+	 0.000000,    0.000000,
 	-0.101993,   -0.098016,
-	0.000000,    0.000000,
-	0.056990,    0.050719,
-	0.000000,    0.000000,
+	 0.000000,    0.000000,
+	 0.056990,    0.050719,
+	 0.000000,    0.000000,
 	-0.036482,   -0.028677,
-	0.000000,    0.000000,
-	0.024377,    0.015947,
-	0.000000,    0.000000,
+	 0.000000,    0.000000,
+	 0.024377,    0.015947,
+	 0.000000,    0.000000,
 	-0.016324,   -0.008242,
-	0.000000,    0.000000,
-	0.010668,    0.003862,
-	0.000000,    0.000000,
+	 0.000000,    0.000000,
+	 0.010668,    0.003862,
+	 0.000000,    0.000000,
 	-0.010233,   -0.001888,
- };
+ } ;
 
 #define	DECIM_TSLICE	(128-1)
 
-static void DecimateBy2binary(int size, char ibuf[][2], fftwf_complex obuf[]) {
-	int i, j, o;
-	float accI, accQ, coef;
-	float coef_0 = COEF[0][FT];
-	float coef_m = COEF[(NTAPS-1)/2][FT];
- 
+static int DecimateBy2float(int size, const fftwf_complex ibuf[], fftwf_complex obuf[], bool yield) {
+	const float coef_0 = COEF[0][FT];
+	const float coef_m = COEF[(NTAPS-1)/2][FT];
 	
-	for (i=o=0; i<size; i+=2, o++) {
-		accI = ibuf[i][0]? coef_0:-coef_0;
-		accQ = ibuf[i][1]? coef_0:-coef_0;
+	for (int i=0, o=0; i<size; i+=2, ++o) {
+		float accI = ibuf[i][0]*coef_0;
+		float accQ = ibuf[i][1]*coef_0;
 
-		for (j=2; j<NTAPS; j+=2) {
-			coef = COEF[j][FT];
-			accI += ibuf[i+j][0]? coef:-coef;
-			accQ += ibuf[i+j][1]? coef:-coef;
-		}
-		
-		accI += ibuf[i+(NTAPS-1)/2][0]? coef_m:-coef_m;
-		accQ += ibuf[i+(NTAPS-1)/2][1]? coef_m:-coef_m;
-
-		obuf[o][0] = Bipolar((accI >= 0)? 1:0);
-		obuf[o][1] = Bipolar((accQ >= 0)? 1:0);
-		
-		if (((i>>1)&DECIM_TSLICE) == DECIM_TSLICE) NextTask("DecimateBy2binary");
-	}
-}
-
-static void DecimateBy2float(int size, fftwf_complex ibuf[], fftwf_complex obuf[], bool yield) {
-	int i, j, o;
-	float accI, accQ, coef;
-	float coef_0 = COEF[0][FT];
-	float coef_m = COEF[(NTAPS-1)/2][FT];
-	
-	for (i=o=0; i<size; i+=2, o++) {
-		coef = COEF[0][FT];
-		accI = ibuf[i][0]*coef_0;
-		accQ = ibuf[i][1]*coef_0;
-
-		for (j=2; j<NTAPS; j+=2) {
-			coef = COEF[j][FT];
+		for (int j=2; j<NTAPS; j+=2) {
+			const float coef = COEF[j][FT];
 			accI += ibuf[i+j][0]*coef;
 			accQ += ibuf[i+j][1]*coef;
 		}
-		
+
 		accI += ibuf[i+(NTAPS-1)/2][0]*coef_m;
 		accQ += ibuf[i+(NTAPS-1)/2][1]*coef_m;
-		
+
 		obuf[o][0] = accI;
 		obuf[o][1] = accQ;
 
 		if (yield && ((i>>1)&DECIM_TSLICE) == DECIM_TSLICE) NextTask("DecimateBy2float");
 	}
+	return size/2;
+}
+
+static int DecimateBy2binary(int size, const char ibuf[][2], fftwf_complex obuf[], bool yield) {
+	// (1) convert the input to a float array
+	simd_bit2float(2*size, (int8_t*)(ibuf), (float*)(obuf));
+	// (2) then use the float version
+	size = DecimateBy2float(size, obuf, obuf, yield);
+	// (3) set output to +-1
+	for (int i=0; i<size; ++i) {
+	 	obuf[i][0] = Bipolar(obuf[i][0] >= 0);
+	  	obuf[i][1] = Bipolar(obuf[i][1] >= 0);
+	}
+	return size;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
 void SearchInit() {
-
-    float ca_rate = CPS/FS;
+    const float ca_rate = CPS/FS;
 	float ca_phase=0;
 
 	printf("DECIM %d FFT %d planning..\n", DECIM, FFT_LEN);
@@ -238,7 +224,6 @@ void SearchInit() {
     rev_plan = fftwf_plan_dft_1d(FFT_LEN, rev_buf, rev_buf, FFTW_BACKWARD, FFTW_ESTIMATE);
 
     for (int sv=0; sv<NUM_SATS; sv++) {
-
 		//printf("computing CODE FFT for PRN%d\n", Sats[sv].prn);
         CACODE ca(Sats[sv].T1, Sats[sv].T2);
 
@@ -247,7 +232,6 @@ void SearchInit() {
             float chip = Bipolar(ca.Chip()); // chip at start of sample period
 
             ca_phase += ca_rate; // NCO phase at end of period
-
             if (ca_phase >= 1.0) { // reached or crossed chip boundary?
                 ca_phase -= 1.0;
                 ca.Clock();
@@ -256,27 +240,22 @@ void SearchInit() {
                 chip *= 1.0 - ca_phase;                 // prev chip
                 chip += ca_phase * Bipolar(ca.Chip());  // next chip
             }
-
-			copy_buf[i][0] = chip;
-			copy_buf[i][1] = 0;
+			fwd_buf[i][0] = chip;
+			fwd_buf[i][1] = 0;
 		}
-		
+
+		assert(DECIM > 1);
 		int nsamples = NSAMPLES;
-
-		if (DECIM > 2) {
-			DecimateBy2float(nsamples, copy_buf, copy_buf, false);
-			nsamples>>=1;
-	
-			for (int i=DECIM>>2; i>1; i>>=1) {
-				DecimateBy2float(nsamples, copy_buf, copy_buf, false);
-				nsamples>>=1;
-			}
+		for (int i=DECIM; i>1; i>>=1) {
+			nsamples = DecimateBy2float(nsamples, fwd_buf, fwd_buf, false);
 		}
+		assert(nsamples == NSAMPLES/DECIM && nsamples == FFT_LEN);
 
-        assert(nsamples/2 == FFT_LEN);
-		DecimateBy2float(nsamples, copy_buf, fwd_buf, false);
 		fftwf_execute(fwd_plan);
-		memcpy(code[sv], fwd_buf, sizeof fwd_buf);
+
+		// make two copies of the FFT results in order to avoid modulo operation on the index in Correlate(..)
+		memcpy(code[sv],          fwd_buf, nsamples*sizeof(fftwf_complex));
+		memcpy(code[sv]+nsamples, fwd_buf, nsamples*sizeof(fftwf_complex));
     }
 
     CreateTask(SearchTask, 0, GPS_ACQ_PRIORITY);
@@ -294,14 +273,14 @@ void SearchFree() {
 static void Sample() {
     const int lo_sin[] = {1,1,0,0}; // Quadrature local oscillators
     const int lo_cos[] = {1,0,0,1};
-
+	
     const float lo_rate = 4*FC/FS; // NCO rate
 
-    const int US = 1000000/BIN_SIZE; // Sample length
+    const int US = int(0.5+1000000/BIN_SIZE); // Sample length
     const int PACKET = GPS_SAMPS * 2;
 
     float lo_phase=0; // NCO phase accumulator
-    int i=0, j, b;
+    int i=0;
 	
 	spi_set(CmdSample); // Trigger sampler and reset code generator in FPGA
 	TaskSleepUsec(US);
@@ -310,12 +289,11 @@ static void Sample() {
         static SPI_MISO rx;
 		spi_get(CmdGetGPSSamples, &rx, PACKET);
 
-        for (j=0; j<PACKET; j++) {
+        for (int j=0; j<PACKET; ++j) {
 			int byte = rx.byte[j];
 
-            for (b=0; b<8; b++) {
-            	int bit = byte&1;
-				byte>>=1;
+            for (int b=0; b<8; ++b, ++i, byte>>=1) {
+            	const int bit = (byte&1);
 
                 // Down convert to complex (IQ) baseband by mixing (XORing)
                 // samples with quadrature local oscillators (mix down by both FS and FC)
@@ -325,44 +303,29 @@ static void Sample() {
 				bits[i][0] = bit ^ lo_sin[int(lo_phase)];
 				bits[i][1] = bit ^ lo_cos[int(lo_phase)];
 
-				i++;
                 lo_phase += lo_rate;
-                if (lo_phase>=4) lo_phase-=4;
+				lo_phase -= 4*(lo_phase >= 4);
             }
         }
     }
 
     NextTask("samp0");
-
-	int nsamples = NSAMPLES;
-
-	if (DECIM == 2) {
-		DecimateBy2binary(nsamples, bits, fwd_buf);
-	} else {
-		DecimateBy2binary(nsamples, bits, copy_buf);
-		nsamples>>=1;
-		NextTask("samp2");
-	
-		for (i=DECIM>>2; i>1; i>>=1) {
-			DecimateBy2float(nsamples, copy_buf, copy_buf, true);
-			nsamples>>=1;
-			NextTask("samp3");
-		}
-		
-        assert(nsamples/2 == FFT_LEN);
-		DecimateBy2float(nsamples, copy_buf, fwd_buf, true);
-	}
+	assert(DECIM > 1);
+	int nsamples = DecimateBy2binary(NSAMPLES, bits, fwd_buf, true);
+	NextTask("samp2");
+	for (i=DECIM>>1; i>1; i>>=1) {
+		nsamples = DecimateBy2float(nsamples, fwd_buf, fwd_buf, true);
+		NextTask("samp3");
+	}		
+	assert(nsamples == NSAMPLES/DECIM);
 	NextTask("samp4");
-
 	fftwf_execute(fwd_plan); // Transform to frequency domain
-
     NextTask("samp5");
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-static float Correlate(int sv, fftwf_complex *data, int *max_snr_dop, int *max_snr_i) {
-
+static float Correlate(int sv, const fftwf_complex *data, int *max_snr_dop, int *max_snr_i) {
     fftwf_complex *prod = rev_buf;
     float max_snr=0;
     int i;
@@ -377,29 +340,23 @@ static float Correlate(int sv, fftwf_complex *data, int *max_snr_dop, int *max_s
         float max_pwr=0, tot_pwr=0;
         int max_pwr_i=0;
 
-        // (a-ib)(x+iy) = (ax+by) + i(ay-bx)
-        for (i=0; i<FFT_LEN; i++) {
-            int j = (i-dop+FFT_LEN) % FFT_LEN;  // doppler shifting applied to C/A code FFT
-            prod[i][0] = data[i][0]*code[sv][j][0] + data[i][1]*code[sv][j][1];
-            prod[i][1] = data[i][0]*code[sv][j][1] - data[i][1]*code[sv][j][0];
-        }
-
-        NextTaskP("coor FFT LONG RUN", NT_LONG_RUN);
-        fftwf_execute(rev_plan);
+		// prod = conj(data)*code, with doppler shifting applied to C/A code FFT
+		simd_multiply_conjugate(FFT_LEN, data, code[sv]+FFT_LEN-dop, prod);
+        NextTaskP("corr FFT LONG RUN", NT_LONG_RUN);
+		fftwf_execute(rev_plan);
         NextTask("corr FFT end");
 
-        for (i=0; i < SAMPLE_RATE/1000; i++) {		// 1 msec of samples
-            float pwr = prod[i][0]*prod[i][0] + prod[i][1]*prod[i][1];
+        for (i=0; i<SAMPLE_RATE/1000; i++) {		// 1 msec of samples
+            const float pwr = prod[i][0]*prod[i][0] + prod[i][1]*prod[i][1];
             if (pwr>max_pwr) max_pwr=pwr, max_pwr_i=i;
             tot_pwr += pwr;
         }
         NextTask("corr pwr");
 
-        float ave_pwr = tot_pwr/i;
-        float snr = max_pwr/ave_pwr;
+        const float ave_pwr = tot_pwr/i;
+        const float snr = max_pwr/ave_pwr;
         if (snr>max_snr) max_snr=snr, *max_snr_dop=dop, *max_snr_i=max_pwr_i;
-    }
-    
+    }		
     return max_snr;
 }
 
@@ -450,7 +407,6 @@ void SearchTask(void *param) {
 			}
 			
 			if ((last_ch != ch) && (snr < min_sig)) GPSstat(STAT_PRN, 0, last_ch, 0, 0, 0);
-
 #ifndef	QUIET
 			printf("FFT-PRN%d\n", sv+1); fflush(stdout);
 #endif
@@ -461,9 +417,8 @@ void SearchTask(void *param) {
 			ca_shift *= DECIM;
             
             us = timer_us()-us;
-
 #ifndef	QUIET
-			printf("FFT-PRN%d %1.1f secs SNR=%1.1f\n", sv+1,
+			printf("FFT-PRN%d %8.6f secs SNR=%1.1f\n", sv+1,
 				(float)us/1000000.0, snr);
 			fflush(stdout);
 #endif

--- a/support/simd.cpp
+++ b/support/simd.cpp
@@ -1,0 +1,79 @@
+// -*- C++ -*-
+
+#include <complex>
+
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif
+
+#include "simd.h"
+
+// c = conj(a) * b
+void simd_multiply_conjugate(int len,
+							 const fftwf_complex* a,
+							 const fftwf_complex* b,
+							 fftwf_complex* c)
+{
+    const std::complex<float>* pa = reinterpret_cast<const std::complex<float>*>(a);
+    const std::complex<float>* pb = reinterpret_cast<const std::complex<float>*>(b);
+    std::complex<float>*       pc = reinterpret_cast<std::complex<float>*>(c);
+
+    int counter=0;
+#ifdef __ARM_NEON
+    register float32x4x2_t u, v, w;
+    for (counter=0; counter<len/4; ++counter) {
+        __builtin_prefetch(pa+256);
+        __builtin_prefetch(pb+256);
+        u = vld2q_f32((const float32_t*)pa); // [r1, i1]
+        v = vld2q_f32((const float32_t*)pb); // [r2, i2]
+        w.val[0] = vmulq_f32(u.val[0], v.val[0]);           // rw  = r1*r1
+        w.val[1] = vmulq_f32(u.val[0], v.val[1]);           // iw  = r1*i2
+        w.val[0] = vmlaq_f32(w.val[0], u.val[1], v.val[1]); // rw += i1*i2
+        w.val[1] = vmlsq_f32(w.val[1], u.val[1], v.val[0]); // iw -= i1*r2
+        vst2q_f32((float32_t*)pc, w);
+        pa+=4, pb+=4, pc+=4;
+    }
+    counter *= 4;
+#endif
+    for (; counter<len; ++counter)
+        *pc++  = std::conj(*pa++)*(*pb++);
+}
+
+// f = (c>0 ? 1.0 : -1.0)
+void simd_bit2float(int len, const int8_t* cv, float* fv)
+{
+    int counter=0;
+#ifdef __ARM_NEON
+    const int8x8_t tbl[4] = { { 0,-1,-1,-1, 2,-1,-1,-1 },
+                              { 4,-1,-1,-1, 6,-1,-1,-1 },
+                              { 1,-1,-1,-1, 3,-1,-1,-1 },
+                              { 5,-1,-1,-1, 7,-1,-1,-1 }};
+    const float32x4_t minus_one = { -1,-1,-1,-1 };
+	const float32x4_t zero      = {  0, 0, 0, 0 };
+	const float32x4_t plus_one  = {  1, 1, 1, 1 };
+
+    for (; counter<len/8; ++counter) {
+        __builtin_prefetch(cv+256,0,0);
+        int8x8_t p = vld1_s8(cv);
+        int8x8x2_t    t0 = { vtbl1_s8(p, tbl[0]),
+							 vtbl1_s8(p, tbl[1]) };
+        int8x8x2_t    t1 = { vtbl1_s8(p, tbl[2]),
+							 vtbl1_s8(p, tbl[3]) };        
+        float32x4x2_t ff = { vcvtq_f32_s32(vreinterpretq_s32_s8(vcombine_s8(t0.val[0], t0.val[1]))),
+                             vcvtq_f32_s32(vreinterpretq_s32_s8(vcombine_s8(t1.val[0], t1.val[1]))) };
+		uint32x4_t b0 = vcgtq_f32(ff.val[0], zero);
+		ff.val[0] = vreinterpretq_f32_u32(vorrq_u32(vandq_u32(vreinterpretq_u32_f32(plus_one),  b0),
+													vbicq_u32(vreinterpretq_u32_f32(minus_one), b0)));
+		uint32x4_t b1 = vcgtq_f32(ff.val[1], zero);
+		ff.val[1] = vreinterpretq_f32_u32(vorrq_u32(vandq_u32(vreinterpretq_u32_f32(plus_one),  b1),
+													vbicq_u32(vreinterpretq_u32_f32(minus_one), b1)));		
+        vst2q_f32(fv, ff);
+        fv += 8;
+        cv += 8;
+    }
+    counter *= 8;
+#endif
+    for (; counter<len; ++counter, ++cv) {
+        *fv++ = float(2*(*cv>0) - 1);
+    }
+}

--- a/support/simd.h
+++ b/support/simd.h
@@ -1,0 +1,18 @@
+// -*- C++ -*-
+
+#ifndef SUPPORT_SIMD_H
+#define SUPPORT_SIMD_H
+
+#include <stdint.h>
+#include <fftw3.h>
+
+// c = conj(a)*b
+extern void simd_multiply_conjugate(int len,
+                                    const fftwf_complex* a,
+                                    const fftwf_complex* b,
+                                    fftwf_complex* c);
+// fv = float(2*(cv>0)-1)
+extern void simd_bit2float(int len, const int8_t* cv, float* fv);
+
+#endif // SUPPORT_SIMD_H
+


### PR DESCRIPTION
 * added a SIMD routine for the correlation cross product
 * GPS sample decimation streamlined
 * `gps/search.cpp` and `support/simd.cpp` are compiled with unsafe math optimizations: `CFLAGS_UNSAFE_OPT = -fcx-limited-range -funsafe-math-optimizations` is the smallest subset of `-ffast-math` I have found which still reduces the time spent in `Sample() `and `Correlate()` from ~110ms to ~62ms.

Please check carefully all changes.