### PR TITLE
Add an audio recording button

### DIFF
--- a/web/openwebrx/audio.js
+++ b/web/openwebrx/audio.js
@@ -689,6 +689,23 @@ function audio_recv(data)
 	audio_stat_total_input_size += samps;
 
 	extint_audio_data(audio_data, samps);
+
+	// Recording hooks
+	if (window.recording) {
+		// There are 512 little-endian samples in each audio_data, the rest of the elements are zeroes
+		for (var i = 0; i < 512; ++i) {
+			window.recording_meta.data.setInt16(window.recording_meta.offset, audio_data[i], true);
+			window.recording_meta.offset += 2;
+		}
+		window.recording_meta.total_size += 512;
+
+		// Check if it's time for a new buffer yet
+		if (window.recording_meta.offset == 65536) {
+			window.recording_meta.buffers.push(new ArrayBuffer(65536));
+			window.recording_meta.data = new DataView(window.recording_meta.buffers[window.recording_meta.buffers.length - 1]);
+			window.recording_meta.offset = 0;
+		}
+	}
 }
 
 var audio_push_ct = 0;

--- a/web/openwebrx/audio.js
+++ b/web/openwebrx/audio.js
@@ -692,12 +692,14 @@ function audio_recv(data)
 
 	// Recording hooks
 	if (window.recording) {
-		// There are 512 little-endian samples in each audio_data, the rest of the elements are zeroes
-		for (var i = 0; i < 512; ++i) {
+		var samples = compressed ? 2048 : 512;
+
+		// There are 2048 or 512 little-endian samples in each audio_data, the rest of the elements are zeroes
+		for (var i = 0; i < samples; ++i) {
 			window.recording_meta.data.setInt16(window.recording_meta.offset, audio_data[i], true);
 			window.recording_meta.offset += 2;
 		}
-		window.recording_meta.total_size += 512;
+		window.recording_meta.total_size += samples * 2;
 
 		// Check if it's time for a new buffer yet
 		if (window.recording_meta.offset == 65536) {

--- a/web/openwebrx/openwebrx.js
+++ b/web/openwebrx/openwebrx.js
@@ -5086,6 +5086,7 @@ function keyboard_shortcut_init()
             w3_table_row('', w3_table_cells('w3-padding-tiny', 't T', 'scroll frequency memory list')),
             w3_table_row('', w3_table_cells('w3-padding-tiny', 'a l u c f i', 'select mode: AM LSB USB CW NBFM IQ')),
             w3_table_row('', w3_table_cells('w3-padding-tiny', 'p P', 'passband narrow/widen')),
+            w3_table_row('', w3_table_cells('w3-padding-tiny', 'r', 'toggle audio recording')),
             w3_table_row('', w3_table_cells('w3-padding-tiny', 'z Z', 'zoom in/out, add alt/ctrl for max in/out')),
             w3_table_row('', w3_table_cells('w3-padding-tiny', '< >', 'waterfall page down/up')),
             w3_table_row('', w3_table_cells('w3-padding-tiny', 'w W', 'waterfall min dB slider -/+ 1 dB, add alt/ctrl for -/+ 10 dB')),

--- a/web/openwebrx/openwebrx.js
+++ b/web/openwebrx/openwebrx.js
@@ -5899,6 +5899,7 @@ var muted_until_freq_set = true;
 var muted = false;
 var volume = 50;
 var f_volume = 0;
+var recording = false;
 
 function setvolume(done, str)
 {
@@ -5924,6 +5925,14 @@ console.log('toggle_or_set_mute set='+ set +' muted='+ muted);
 	if (el) el.style.color = muted? 'lime':'white';
    f_volume = muted? 0 : volume/100;
    freqset_select();
+}
+
+function toggle_or_set_rec(set)
+{
+   recording = !recording;
+   console.log('toggle_or_set_rec set=' + set + ' recording=' + recording);
+   var el = w3_el('id-btn-grp-1');
+   el.style.color = recording ? 'red' : 'lime';
 }
 
 // squelch
@@ -6467,7 +6476,10 @@ function panel_setup_control(el)
 	   w3_table('id-control-1') +
 
       w3_col_percent('w3-vcenter w3-margin-T-4', '',
-         w3_table('id-control-2'), 90,
+         w3_table('id-control-2'), 85,
+         w3_div('id-rec w3_show_inline',
+           w3_icon('', 'fa-circle', '2em', 'lime', 'toggle_or_set_rec')
+         ), 5,
          w3_div('',
             //w3_icon('id-mute-no w3-center|width:100%;', 'fa-volume-up', '2em', 'lime', 'toggle_or_set_mute'),
             //w3_icon('id-mute-yes w3-center w3-hide|width:100%;', 'fa-volume-off', 20, 'red', 'toggle_or_set_mute')

--- a/web/openwebrx/openwebrx.js
+++ b/web/openwebrx/openwebrx.js
@@ -5972,8 +5972,10 @@ function toggle_or_set_rec(set)
       a.style = 'display: none';
       a.href = window.URL.createObjectURL(wav_file);
       a.download = window.recording_meta.filename;
+      document.body.appendChild(a); // https://bugzilla.mozilla.org/show_bug.cgi?id=1218456
       a.click();
       window.URL.revokeObjectURL(a.href);
+      document.body.removeChild(a);
 
       delete window.recording_meta;
    }

--- a/web/openwebrx/openwebrx.js
+++ b/web/openwebrx/openwebrx.js
@@ -5222,6 +5222,7 @@ function keyboard_shortcut(evt)
 
          // misc
          case 'o': keyboard_shortcut_nav(shortcut.nav_off? 'status':'off'); shortcut.nav_off ^= 1; break;
+         case 'r': toggle_or_set_rec(); break;
          case '?': case 'h': keyboard_shortcut_help(); break;
          default: action = false; break;
          


### PR DESCRIPTION
This PR adds a button to the main control panel that records audio directly, next to the speaker icon (why are there two mute buttons in that panel, BTW?). Clicking it turns the icon red, and starts recording audio. Clicking it again turns it back to lime, and immediately downloads a .wav file with recorded audio.

While recording is on, there are several restrictions:

* While recording in IQ mode, all other modes are locked out, because they are mono. While recording in all other modes, the IQ mode is locked out, because it is stereo.
* The compression setting is fixed for the entire recording. Had some bugs with on the fly changes.

The recording icon is not really positioned perfectly in the UI right now.

I've tested this only in Chrome 67. Couldn't test it elsewhere.