### PR TITLE
clean termination of websocket connections kicked out by the server

### DIFF
--- a/kiwi.h
+++ b/kiwi.h
@@ -89,11 +89,13 @@ void dump();
 void c2s_sound_init();
 void c2s_sound_setup(void *param);
 void c2s_sound(void *param);
+void c2s_sound_shutdown(void *param);
 
 void c2s_waterfall_init();
 void c2s_waterfall_compression(int rx_chan, bool compression);
 void c2s_waterfall_setup(void *param);
 void c2s_waterfall(void *param);
+void c2s_waterfall_shutdown(void *param);
 
 void c2s_admin_setup(void *param);
 void c2s_admin_shutdown(void *param);

--- a/rx/rx_server.cpp
+++ b/rx/rx_server.cpp
@@ -55,12 +55,12 @@ rx_chan_t rx_channels[MAX_RX_CHANS];
 // NB: must be in conn_t.type order
 rx_stream_t streams[] = {
 	{ AJAX_VERSION,		"VER" },
-	{ STREAM_ADMIN,		"admin",	&c2s_admin,		&c2s_admin_setup,		&c2s_admin_shutdown,	ADMIN_PRIORITY },
+	{ STREAM_ADMIN,		"admin",	&c2s_admin,		&c2s_admin_setup,		&c2s_admin_shutdown,	 ADMIN_PRIORITY },
 #ifndef CFG_GPS_ONLY
-	{ STREAM_SOUND,		"SND",		&c2s_sound,		&c2s_sound_setup,		NULL,                   SND_PRIORITY },
-	{ STREAM_WATERFALL,	"W/F",		&c2s_waterfall,	&c2s_waterfall_setup,	NULL,                   WF_PRIORITY },
-	{ STREAM_MFG,		"mfg",		&c2s_mfg,		&c2s_mfg_setup,			NULL,                   ADMIN_PRIORITY },
-	{ STREAM_EXT,		"EXT",		&extint_c2s,	&extint_setup_c2s,		NULL,                   EXT_PRIORITY },
+	{ STREAM_SOUND,		"SND",		&c2s_sound,		&c2s_sound_setup,		&c2s_sound_shutdown,	 SND_PRIORITY },
+	{ STREAM_WATERFALL,	"W/F",		&c2s_waterfall,	&c2s_waterfall_setup,	&c2s_waterfall_shutdown, WF_PRIORITY },
+	{ STREAM_MFG,		"mfg",		&c2s_mfg,		&c2s_mfg_setup,			NULL,                    ADMIN_PRIORITY },
+	{ STREAM_EXT,		"EXT",		&extint_c2s,	&extint_setup_c2s,		NULL,                    EXT_PRIORITY },
 
 	// AJAX requests
 	{ AJAX_DISCOVERY,	"DIS" },
@@ -412,6 +412,7 @@ conn_t *rx_server_websocket(websocket_mode_e mode, struct mg_connection *mc)
         
         if (mode == WS_MODE_CLOSE) {
             //cprintf(c, "WS_MODE_CLOSE %s KA=%02d/60 KC=%05d\n", streams[c->type].uri, c->keep_alive, c->keepalive_count);
+            mg_websocket_write(mc, WS_OPCODE_CLOSE, "", 0);
             c->mc = NULL;
             c->kick = true;
             return NULL;

--- a/rx/rx_waterfall.cpp
+++ b/rx/rx_waterfall.cpp
@@ -1061,3 +1061,10 @@ if (i == 516) printf("\n");
 		last_time[rx_chan] = now;
 	#endif
 }
+
+void c2s_waterfall_shutdown(void *param)
+{
+    conn_t *c = (conn_t*)(param);
+    if (c && c->mc)
+        rx_server_websocket(WS_MODE_CLOSE, c->mc);
+}


### PR DESCRIPTION
Before the SND (and WF) process just stopped to send data to the websocket
server. Because of this, mongoose sent a ping packet after a timeout
of 5 sec, expecting an immediate answer from the client and then closed the connection.
But the client had no way of knowing that its connection was being closed by the server.

Now the server sends a close request packet to the client which allows to
terminate the websocket connection in a clean way.

This commit also contains a minor change in the way the time difference to the last GNSS solution is computed.