### PR TITLE
delay adjustment for 20kHz mode

### DIFF
--- a/rx/rx_sound.cpp
+++ b/rx/rx_sound.cpp
@@ -170,9 +170,9 @@ void c2s_sound(void *param)
 	switch (fw_sel) {
 	    case FW_SEL_SDR_RX4_WF4: norm_nrx_samps = nrx_samps - ref_nrx_samps; break;
 	    case FW_SEL_SDR_RX8_WF2: norm_nrx_samps = nrx_samps; break;
-	    case FW_SEL_SDR_RX3_WF3: const double target = 0.0048;      // empirically measured using GPS 1 PPS input
+	    case FW_SEL_SDR_RX3_WF3: const double target = 15960.828e-6;      // empirically measured using GPS 1 PPS input
 	                             norm_nrx_samps = (int) (target * SND_RATE_3CH);
-	                             gps_delay2 = target - (double) norm_nrx_samps / SND_RATE_3CH;
+	                             gps_delay2 = target - (double) norm_nrx_samps / SND_RATE_3CH; // fractional part of target delay
 	                             break;
 	}
 	//printf("rx_chans=%d norm_nrx_samps=%d nrx_samps=%d ref_nrx_samps=%d gps_delay2=%e\n",
@@ -620,7 +620,7 @@ void c2s_sound(void *param)
 			last_ticks[rx_chan] = ticks;
 			tick_seq[rx_chan]++;
 #endif
-			gps_ts[rx_chan].gpssec = fmod(gps_week_sec + clk.gps_secs + dt/clk.adc_clock_base - gps_delay - gps_delay2, gps_week_sec);
+			gps_ts[rx_chan].gpssec = fmod(gps_week_sec + clk.gps_secs + dt/clk.adc_clock_base - gps_delay + gps_delay2, gps_week_sec);
 
 		    #ifdef SND_SEQ_CHECK
 		        if (rx->in_seq[rx->rd_pos] != snd->snd_seq) {


### PR DESCRIPTION
The plot below shows the peak of the 1PPS pulse _w.r.t._ `mod(gpssec+0.5,1)-0.5` for 4-ch, 8-ch and 3-ch modes, measured at G8JNJ (many thanks to Martin for making his 2nd KiwiSDR available for these tests). The solid lines are least-squares fits of parabolae to the peaks and the deltaT values are obtained from the fits.

As one sample is ~83.3 usec (~49.4 usec) long for 12 kHz (20.25 kHz) sampling rate it is difficult to obtain more than _O_(0.1 usec) precision for the time delays.

![g8jnj_alignment](https://user-images.githubusercontent.com/7550829/50652446-d419b680-0f86-11e9-8e32-87ca6ed7d2f3.png)

Note that `gps_delay2` has to be added in [L623](https://github.com/hcab14/Beagle_SDR_GPS/blob/955c8f68dd665f8af269b7576658751129c02788/rx/rx_sound.cpp#L623) because `norm_nrx_samps` is also added to the timestamps ([L678](https://github.com/hcab14/Beagle_SDR_GPS/blob/955c8f68dd665f8af269b7576658751129c02788/rx/rx_sound.cpp#L678)) in [rx/rx_sound.cpp](https://github.com/hcab14/Beagle_SDR_GPS/blob/955c8f68dd665f8af269b7576658751129c02788/rx/rx_sound.cpp).
`