### PR TITLE
do not reset the FIR filter position when resetting gps_timestamp_t

### DIFF
--- a/rx/CuteSDR/fastfir.h
+++ b/rx/CuteSDR/fastfir.h
@@ -28,6 +28,7 @@ public:
 	void SetupParameters( TYPEREAL FLoCut,TYPEREAL FHiCut,TYPEREAL Offset, TYPEREAL SampleRate);
 	int ProcessData(int rx_chan, int InLength, TYPECPX* InBuf, TYPECPX* OutBuf);
 
+	int FirPos() const { return m_InBufInPos - CONV_FIR_SIZE + 1; }
 private:
 	inline void CpxMpy(int N, TYPECPX* m, TYPECPX* src, TYPECPX* dest);
 


### PR DESCRIPTION
- commit https://github.com/jks-prv/Beagle_SDR_GPS/commit/c4a7770772fb9c68a29bc288a2b40e958b7c47c8 introduced random offsets in the GNSS timestamps for each connection
- instead of tracking the FIR filter position for each RX channel, the FIR filter position is now obtained from the CuteSDR FFT FIR filter itself