### PR TITLE
Only reference fftw3f library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,13 +197,13 @@ CFILES_O3 = $(subst web/web.cpp,,$(CPP_F_O3))
 
 ifeq ($(DEBIAN_DEVSYS),$(DEVSYS))
 	ifeq ($(XC),-DXC)
-		LIBS += -lfftw3f -lfftw3 -lutil
+		LIBS += -lfftw3f -lutil
 		DIR_CFG = /root/kiwi.config
 		CFG_PREFIX =
 	else
 		# development machine, compile simulation version
-		LIBS += -L/usr/local/lib -lfftw3f -lfftw3
-		LIBS_DEP += /usr/local/lib/libfftw3f.a /usr/local/lib/libfftw3.a
+		LIBS += -L/usr/local/lib -lfftw3f
+		LIBS_DEP += /usr/local/lib/libfftw3f.a
 		CMD_DEPS =
 		DIR_CFG = unix_env/kiwi.config
 		CFG_PREFIX = dist.
@@ -211,8 +211,8 @@ ifeq ($(DEBIAN_DEVSYS),$(DEVSYS))
 
 else
 	# host machine (BBB), only build the FPGA-using version
-	LIBS += -lfftw3f -lfftw3 -lutil
-	LIBS_DEP += /usr/lib/arm-linux-gnueabihf/libfftw3f.a /usr/lib/arm-linux-gnueabihf/libfftw3.a
+	LIBS += -lfftw3f -lutil
+	LIBS_DEP += /usr/lib/arm-linux-gnueabihf/libfftw3f.a
 	CMD_DEPS = $(CMD_DEPS_DEBIAN) /usr/sbin/avahi-autoipd /usr/bin/upnpc /usr/bin/dig /usr/bin/pnmtopng /sbin/ethtool /usr/bin/sshpass
 	CMD_DEPS += /usr/bin/killall /usr/bin/dtc /usr/bin/curl /usr/bin/wget
 	DIR_CFG = /root/kiwi.config
@@ -254,7 +254,7 @@ endif
 	@mkdir -p $(DIR_CFG)
 	touch $(KEYRING)
 
-/usr/lib/arm-linux-gnueabihf/libfftw3f.a /usr/lib/arm-linux-gnueabihf/libfftw3.a:
+/usr/lib/arm-linux-gnueabihf/libfftw3f.a:
 	apt-get -y install libfftw3-dev
 
 # NB not a typo: "clang-6.0" vs "clang-7"

--- a/extensions/DRM/dream/matlib/MatlibStdToolbox.cpp
+++ b/extensions/DRM/dream/matlib/MatlibStdToolbox.cpp
@@ -467,8 +467,8 @@ CMatlibVector<CComplex> Fft(const CMatlibVector<CComplex>& cvI,
 							CFftPlans& FftPlans)
 {
 	int				i;
-	fftw_complex*	pFftwComplexIn;
-	fftw_complex*	pFftwComplexOut;
+	fftwf_complex*	pFftwComplexIn;
+	fftwf_complex*	pFftwComplexOut;
 
 	const int				n(cvI.GetSize());
 
@@ -492,7 +492,7 @@ CMatlibVector<CComplex> Fft(const CMatlibVector<CComplex>& cvI,
 	}
 
 	/* Actual fftw call */
-	fftw_execute(FftPlans.FFTPlForw);
+	fftwf_execute(FftPlans.FFTPlForw);
 
 	for (i = 0; i < n; i++)
 		cvReturn[i] = CComplex(pFftwComplexOut[i][0], pFftwComplexOut[i][1]);
@@ -504,8 +504,8 @@ CMatlibVector<CComplex> Ifft(const CMatlibVector<CComplex>& cvI,
 							 CFftPlans& FftPlans)
 {
 	int				i;
-	fftw_complex*	pFftwComplexIn;
-	fftw_complex*	pFftwComplexOut;
+	fftwf_complex*	pFftwComplexIn;
+	fftwf_complex*	pFftwComplexOut;
 
 	const int		n(cvI.GetSize());
 
@@ -529,7 +529,7 @@ CMatlibVector<CComplex> Ifft(const CMatlibVector<CComplex>& cvI,
 	}
 
 	/* Actual fftw call */
-	fftw_execute(FftPlans.FFTPlBackw);
+	fftwf_execute(FftPlans.FFTPlBackw);
 	
 	const CReal scale = (CReal) 1.0 / n;
 	for (i = 0; i < n; i++)
@@ -545,8 +545,8 @@ CMatlibVector<CComplex> rfft(const CMatlibVector<CReal>& fvI,
 							 CFftPlans& FftPlans)
 {
 	int			i;
-	double* 	pFftwRealIn;
-	double* 	pFftwRealOut;
+	float* 	pFftwRealIn;
+	float* 	pFftwRealOut;
 
 	const int	iSizeI = fvI.GetSize();
 	const int	iLongLength(iSizeI);
@@ -571,7 +571,7 @@ CMatlibVector<CComplex> rfft(const CMatlibVector<CReal>& fvI,
 		pFftwRealIn[i] = fvI[i];
 
 	/* Actual fftw call */
-	fftw_execute(FftPlans.RFFTPlForw);
+	fftwf_execute(FftPlans.RFFTPlForw);
 
 	/* Now build complex output vector */
 	/* Zero frequency */
@@ -593,8 +593,8 @@ CMatlibVector<CReal> rifft(const CMatlibVector<CComplex>& cvI,
 	This function only works with EVEN N!
 */
 	int			i;
-	double*		pFftwRealIn;
-	double*		pFftwRealOut;
+	float*		pFftwRealIn;
+	float*		pFftwRealOut;
 
 	const int	iShortLength(cvI.GetSize() - 1); /* Nyquist frequency! */
 	const int	iLongLength(iShortLength * 2);
@@ -622,7 +622,7 @@ CMatlibVector<CReal> rifft(const CMatlibVector<CComplex>& cvI,
 	pFftwRealIn[iShortLength] = cvI[iShortLength].real(); 
 
 	/* Actual fftw call */
-	fftw_execute(FftPlans.RFFTPlBackw);
+	fftwf_execute(FftPlans.RFFTPlBackw);
 
 	/* Scale output vector */
 	const CReal scale = (CReal) 1.0 / iLongLength;
@@ -715,16 +715,16 @@ void CFftPlans::Init(const int iFSi, EFFTPlan eFFTPlan)
 		switch (eFFTPlan)
 		{
 		case FP_RFFTPlForw:
-			RFFTPlForw = fftw_plan_r2r_1d(fftw_n, pFftwRealIn, pFftwRealOut, FFTW_R2HC, PLANNER_FLAGS);
+			RFFTPlForw = fftwf_plan_r2r_1d(fftw_n, pFftwRealIn, pFftwRealOut, FFTW_R2HC, PLANNER_FLAGS);
 			break;
 		case FP_RFFTPlBackw:
-			RFFTPlBackw = fftw_plan_r2r_1d(fftw_n, pFftwRealIn, pFftwRealOut, FFTW_HC2R, PLANNER_FLAGS);
+			RFFTPlBackw = fftwf_plan_r2r_1d(fftw_n, pFftwRealIn, pFftwRealOut, FFTW_HC2R, PLANNER_FLAGS);
 			break;
 		case FP_FFTPlForw:
-			FFTPlForw = fftw_plan_dft_1d(fftw_n, pFftwComplexIn, pFftwComplexOut, FFTW_FORWARD, PLANNER_FLAGS);
+			FFTPlForw = fftwf_plan_dft_1d(fftw_n, pFftwComplexIn, pFftwComplexOut, FFTW_FORWARD, PLANNER_FLAGS);
 			break;
 		case FP_FFTPlBackw:
-			FFTPlBackw = fftw_plan_dft_1d(fftw_n, pFftwComplexIn, pFftwComplexOut, FFTW_BACKWARD, PLANNER_FLAGS);
+			FFTPlBackw = fftwf_plan_dft_1d(fftw_n, pFftwComplexIn, pFftwComplexOut, FFTW_BACKWARD, PLANNER_FLAGS);
 			break;
 		}
 		MATLIB_MUTEX_UNLOCK();
@@ -753,10 +753,10 @@ bool CFftPlans::InitInternal(const int iFSi)
 
 // TODO intermediate buffers should be created only when needed
     /* Create new intermediate buffers */
-	pFftwRealIn = new double[iFSi];
-	pFftwRealOut = new double[iFSi];
-	pFftwComplexIn = new fftw_complex[iFSi];
-	pFftwComplexOut = new fftw_complex[iFSi];
+	pFftwRealIn = new float[iFSi];
+	pFftwRealOut = new float[iFSi];
+	pFftwComplexIn = new fftwf_complex[iFSi];
+	pFftwComplexOut = new fftwf_complex[iFSi];
 
 	fftw_n = iFSi;
 	bInitialized = true;
@@ -769,10 +769,10 @@ void CFftPlans::Clean()
 	{
 		/* Delete old plans and intermediate buffers */
 		MATLIB_MUTEX_LOCK();
-		if (RFFTPlForw)  fftw_destroy_plan(RFFTPlForw);
-		if (RFFTPlBackw) fftw_destroy_plan(RFFTPlBackw);
-		if (FFTPlForw)   fftw_destroy_plan(FFTPlForw);
-		if (FFTPlBackw)  fftw_destroy_plan(FFTPlBackw);
+		if (RFFTPlForw)  fftwf_destroy_plan(RFFTPlForw);
+		if (RFFTPlBackw) fftwf_destroy_plan(RFFTPlBackw);
+		if (FFTPlForw)   fftwf_destroy_plan(FFTPlForw);
+		if (FFTPlBackw)  fftwf_destroy_plan(FFTPlBackw);
 		MATLIB_MUTEX_UNLOCK();
 
 		delete[] pFftwRealIn;

--- a/extensions/DRM/dream/matlib/MatlibStdToolbox.h
+++ b/extensions/DRM/dream/matlib/MatlibStdToolbox.h
@@ -45,15 +45,15 @@ public:
 	void Init(const int iFSi);
 	void Init(const int iFSi, EFFTPlan eFFTPlan);
 
-	fftw_plan	RFFTPlForw;
-	fftw_plan	RFFTPlBackw;
-	double*		pFftwRealIn;
-	double*		pFftwRealOut;
-	fftw_plan	FFTPlForw;
-	fftw_plan	FFTPlBackw;
+	fftwf_plan	RFFTPlForw;
+	fftwf_plan	RFFTPlBackw;
+	float*		pFftwRealIn;
+	float*		pFftwRealOut;
+	fftwf_plan	FFTPlForw;
+	fftwf_plan	FFTPlBackw;
 
-	fftw_complex*	pFftwComplexIn;
-	fftw_complex*	pFftwComplexOut;
+	fftwf_complex*	pFftwComplexIn;
+	fftwf_complex*	pFftwComplexOut;
 
 protected:
 	void			Clean();

--- a/rx/data_pump.cpp
+++ b/rx/data_pump.cpp
@@ -38,7 +38,6 @@ Boston, MA  02110-1301, USA.
 #include <time.h>
 #include <sched.h>
 #include <math.h>
-#include <fftw3.h>
 
 rx_dpump_t rx_dpump[MAX_RX_CHANS];
 dpump_t dpump;

--- a/rx/data_pump.h
+++ b/rx/data_pump.h
@@ -25,8 +25,6 @@ Boston, MA  02110-1301, USA.
 #include "cuteSDR.h"
 #include "ima_adpcm.h"
 
-#include <fftw3.h>
-
 //#define DATA_PUMP_DEBUG
 
 typedef struct {
@@ -62,7 +60,6 @@ typedef struct {
 	struct {
 	    int rx_chan;
 		u64_t gen, proc;
-		fftwf_complex *wf_c_samps;
 		u4_t desired;
 		float chunk_wait_us;
 		int zoom, samp_wait_ms;

--- a/rx/rx_cmd.cpp
+++ b/rx/rx_cmd.cpp
@@ -49,7 +49,6 @@ Boston, MA  02110-1301, USA.
 #include <math.h>
 #include <limits.h>
 #include <signal.h>
-#include <fftw3.h>
 
 kstr_t *cpu_stats_buf;
 volatile float audio_kbps[MAX_RX_CHANS+1], waterfall_kbps[MAX_RX_CHANS+1], waterfall_fps[MAX_RX_CHANS+1], http_kbps;

--- a/rx/rx_server.cpp
+++ b/rx/rx_server.cpp
@@ -46,7 +46,6 @@ Boston, MA  02110-1301, USA.
 #include <sched.h>
 #include <math.h>
 #include <signal.h>
-#include <fftw3.h>
 
 conn_t conns[N_CONNS];
 

--- a/rx/rx_server_ajax.cpp
+++ b/rx/rx_server_ajax.cpp
@@ -41,7 +41,6 @@ Boston, MA  02110-1301, USA.
 #include <sched.h>
 #include <math.h>
 #include <signal.h>
-#include <fftw3.h>
 #include <stdlib.h>
 #include <sys/time.h>
 

--- a/rx/rx_util.cpp
+++ b/rx/rx_util.cpp
@@ -50,7 +50,6 @@ Boston, MA  02110-1301, USA.
 #include <sched.h>
 #include <math.h>
 #include <signal.h>
-#include <fftw3.h>
 
 // copy admin-related configuration from kiwi.json to new admin.json file
 void cfg_adm_transition()


### PR DESCRIPTION
Use float veresion of fftw3. When I am here, remove fftw3.h from the files which is not actually using it.