### PR TITLE
AGC threshold bar and overload mute

### DIFF
--- a/rx/rx_sound.cpp
+++ b/rx/rx_sound.cpp
@@ -226,13 +226,13 @@ void c2s_sound(void *param)
 	int squelch=0, squelch_on_seq=-1, tail_delay=0;
 	bool sq_init, squelched=false;
 	
-	// OVERLOAD stuff marco
+	// Overload muting stuff
 	bool mute_overload = true; // activate the muting when overloaded
 	bool squelched_overload = false; // squelch flag specific for the overloading
 	bool overload_before = false; // were we overloaded in the previous instant?
 	bool overload_flag = false; // are we overloaded now?
 	int overload_timer = -1; // keep track of when we stopped being overloaded to allow a decay
-	float max_thr = -20; // marco: this is the maximum signal in dBm before muting
+	float max_thr = -15; // this is the maximum signal in dBm before muting
 
 	gps_timestamp_t *gps_tsp = &gps_ts[rx_chan];
 	memset(gps_tsp, 0, sizeof(gps_timestamp_t));
@@ -1215,25 +1215,24 @@ void c2s_sound(void *param)
                     if (is_open) rssi_thresh -= 6;
                     bool rssi_green = (sMeter_dBm >= rssi_thresh);
                     if (rssi_green) {
-                        squelch_on_seq = snd->seq; // mem time when squelch opened
+                        squelch_on_seq = snd->seq;
                         is_open = true;
                     }
                     
                     rtn_is_open = is_open;
                     if (!is_open) rtn_is_open = false; 
                     if (snd->seq > squelch_on_seq + tail_delay) {
-                        squelch_on_seq = -1; // forget when squelch was opened
+                        squelch_on_seq = -1;
                         rtn_is_open = false; 
                     }
-                    printf("median_nf %f, rssi_thresh %f, is_open %d, rss_green %d, sMeter_dBm %f, seq %d, squelch_on_seq %d, squelch_lev %d\n", median_nf, rssi_thresh, is_open, rssi_green, sMeter_dBm, snd->seq, squelch_on_seq, squelch);
-
                 }
                 if (sq_init) sq_init = false;
                 
                 squelched = (!rtn_is_open);
             }
 
-            // mute receiver if overload is detected            
+	// mute receiver if overload is detected
+	// use the same tail_delay parameter user for the squelch
             if (mute_overload) {
             	overload_flag = (sMeter_dBm >= max_thr)?true:false;
             	if (overload_before && !overload_flag) {

--- a/web/openwebrx/openwebrx.js
+++ b/web/openwebrx/openwebrx.js
@@ -6340,7 +6340,7 @@ function smeter_init()
 		sMeter_ctx.fillText(bars.text[i], x, y-15);
 		//console.log("SM x="+x+' dBm='+bars.dBm[i]+' '+bars.text[i]);
 	}
-
+	line_stroke(sMeter_ctx, 0, 2, "black", 0,y-3,w,y-3);
 	line_stroke(sMeter_ctx, 0, 5, "black", 0,y,w,y);
 	setInterval(update_smeter, 100);
 }
@@ -6354,7 +6354,10 @@ function update_smeter()
 	var x = smeter_dBm_biased_to_x(sMeter_dBm_biased);
 	var y = SMETER_SCALE_HEIGHT-8;
 	var w = smeter_width;
+	var x_thr = smeter_dBm_biased_to_x(-thresh);
 	sMeter_ctx.globalAlpha = 1;
+	line_stroke(sMeter_ctx, 0, 2, "white", 0,y-3,w-x_thr,y-3);
+	line_stroke(sMeter_ctx, 0, 2, "black", w-x_thr,y-3,w,y-3);
 	line_stroke(sMeter_ctx, 0, 5, "lime", 0,y,x,y);
 	
 	if (sm_timeout-- == 0) {

--- a/web/openwebrx/openwebrx.js
+++ b/web/openwebrx/openwebrx.js
@@ -6340,6 +6340,7 @@ function smeter_init()
 		sMeter_ctx.fillText(bars.text[i], x, y-15);
 		//console.log("SM x="+x+' dBm='+bars.dBm[i]+' '+bars.text[i]);
 	}
+
 	line_stroke(sMeter_ctx, 0, 2, "black", 0,y-3,w,y-3);
 	line_stroke(sMeter_ctx, 0, 5, "black", 0,y,w,y);
 	setInterval(update_smeter, 100);
@@ -6352,18 +6353,19 @@ var sm_ovfl_showing = false;
 function update_smeter()
 {
 	var x = smeter_dBm_biased_to_x(sMeter_dBm_biased);
+	var x_thr = smeter_dBm_biased_to_x(-thresh);
 	var y = SMETER_SCALE_HEIGHT-8;
 	var w = smeter_width;
-	var x_thr = smeter_dBm_biased_to_x(-thresh);
 	sMeter_ctx.globalAlpha = 1;
+	line_stroke(sMeter_ctx, 0, 5, "lime", 0,y,x,y);
 	line_stroke(sMeter_ctx, 0, 2, "white", 0,y-3,w-x_thr,y-3);
 	line_stroke(sMeter_ctx, 0, 2, "black", w-x_thr,y-3,w,y-3);
-	line_stroke(sMeter_ctx, 0, 5, "lime", 0,y,x,y);
 	
 	if (sm_timeout-- == 0) {
 		sm_timeout = sm_interval;
 		if (x < sm_px) line_stroke(sMeter_ctx, 0, 5, "black", x,y,sm_px,y);
 		//if (x < sm_px) line_stroke(sMeter_ctx, 0, 5, "black", x,y,w,y);
+		
 		sm_px = x;
 	} else {
 		if (x < sm_px) {


### PR DESCRIPTION
Hi John,
as discussed via email, I'm sending a pull request for the AGC threshold visual bar and I was able to implement the audio mute during overload (I set it at -15 dBm). I tested briefly while also transmitting with a 5W-100W radio and selecting a tail decay of 0.2-0.5s it's totally seamless when switching RX and TX.
As far as I can tell, there are no bad interactions with the squelch.

73!
marco / IS0KYB