### PR TITLE
Update sats.cpp to activate QZS-1R L1 C/A signal

### DIFF
--- a/gps/sats.cpp
+++ b/gps/sats.cpp
@@ -84,15 +84,15 @@ SATELLITE Sats[] = {
 */
 
     // QZSS (Japan) prn(saif) = 183++, prn(std) = 193++
-    // last checked: 9-Sep-2020
+    // last checked: 28-Dec-2021
     // sys.qzss.go.jp/dod/en/constellation.html [PNT L1 C/A entries]
     {193, 339, 01050, QZSS},   // J01, QZS-1
     {194, 208, 01607, QZSS},   // J02, QZS-2
-    {195, 711, 01747, QZSS},   // J04, QZS-4
-//  {196, 189, 01305, QZSS},   // (not scheduled until 2023)
+    {195, 711, 01747, QZSS},   // J03, QZS-4
+    {196, 189, 01305, QZSS},   // J04, QZS-1R
 //  {197, 263, 00540, QZSS},   //
 //  {198, 537, 01363, QZSS},   //
-    {199, 663, 00727, QZSS},   // J03, QZS-3
+    {199, 663, 00727, QZSS},   // J07, QZS-3
 //  {200, 942, 00147},
 //  {201, 173, 01206},
 //  {202, 900, 01045},


### PR DESCRIPTION
Please uncomment the satellite data of PRN 196 so that we can make use of QZS-1R (replacement).

It was launched on 2021-10-26. The alert flag will be unset on 2022-01-26 (https://qzss.go.jp/info/information/qzs1r_211222.html and the information is in Japanese only...) and the QZS-1R will be available on 2022-03-03.

SVIDs in QZSS were changed because there are difference between the SVN (space vehicular number) and the SVID (space vehicular identification). For example, the SVID of QZS-4 is 3 and it is denoted J03, say, in  RINEX (page 25 on IS-QZSS-PNT https://qzss.go.jp/en/technical/download/pdf/ps-is-qzss/is-qzss-pnt-004.pdf?t=1641020780449).