### PR TITLE
Update sats.cpp

### DIFF
--- a/gps/sats.cpp
+++ b/gps/sats.cpp
@@ -110,7 +110,7 @@ SATELLITE Sats[] = {
     { 7, 0, 0, E1B},    // gsat0207
     { 8, 0, 0, E1B},    // gsat0208
     { 9, 0, 0, E1B},    // gsat0209
-//  {10, 0, 0, E1B},    // gsat0224 under commissioning
+    {10, 0, 0, E1B},    // gsat0224 Active since 2022-08-29
     {11, 0, 0, E1B},    // gsat0101
     {12, 0, 0, E1B},    // gsat0102
     {13, 0, 0, E1B},    // gsat0220


### PR DESCRIPTION
Hello,
Change proposal, gsat0224 (Galileo E10) is active since 2022-08-29. Here is the info from ESA.
https://www.esa.int/Applications/Navigation/Latest_Galileo_satellites_join_constellation_with_enhanced_faster_fix

Best 73 de Benjamin F4FPR / K5AW.