### PR TITLE
Remove trailing comma in function call

### DIFF
--- a/web/kiwi/monitor.js
+++ b/web/kiwi/monitor.js
@@ -35,7 +35,7 @@ function kiwi_monitor()
          w3_inline('w3-margin-L-8 w3-margin-T-4/w3-margin-right w3-valign',
             w3_button('id-queue-button w3-medium w3-padding-smaller w3-green', 'Enter queue', 'kiwi_queue_cb'),
             w3_text('id-queue-pos w3-text-black'),
-            w3_button('id-queue-button w3-medium w3-padding-smaller w3-yellow', 'Reload page', 'kiwi_queue_reload_cb'),
+            w3_button('id-queue-button w3-medium w3-padding-smaller w3-yellow', 'Reload page', 'kiwi_queue_reload_cb')
          ),
          w3_text('id-queue-status w3-margin-T-4 w3-text-black', ''),
 


### PR DESCRIPTION
This causes syntax errors and prevents loading on some runtimes, and as of v1.602, it isn't corrected anymore by the new JavaScript minifier.