### PR TITLE
fix: lower buffer size for pskreporter uploads to avoid data loss from fragmentation

### DIFF
--- a/extensions/FT8/PSKReporter.cpp
+++ b/extensions/FT8/PSKReporter.cpp
@@ -146,7 +146,7 @@ struct {
 
 // PR_TX_LINK, len, call, freq, snr, mode, grid, isrc, slot_time, pad (max), slop
 #define PR_TX_MAX_LEN   (2 + 2 + (1+14) + 4 + 1 + (1+3) + (1+6) + 1 + 4 + 3 + 16)
-#define PR_BUF_LEN 2048
+#define PR_BUF_LEN 1190
 
 typedef struct {
 	bool task_created;


### PR DESCRIPTION
This change lowers the buffer size from 2048 to 1190 bytes that's used for limiting the maximum packet size used in uploads to PSKReporter. The current buffer size is 2048, which is well above the common Ethernet MTU of 1500. When the payload is above the effective MTU over the Internet, it gets fragmented into multiple packets. For various reasons, usually not all packets make it, which leaves the total payload malformed. For this subset of users, the impact is ~100% data loss of spot uploads.

The 1,190 byte limit will add no practical overhead (spot data is very small), and will fix the data loss issue. The value is based on an analysis of actual incoming PSKReporter traffic, showing fragmented traffic lies in the 1,210-1,500 byte range.

